### PR TITLE
Fix syntax highlighting for JSON in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This snippet makes creating the basic HTML structure easy.
 You can also use <kbd>⇥ Tab</kbd> to jump to the next placeholder.
 
 ## Code
-```json
+```jsonc
 {
     // Example orgiginally by Visual Studio Code:
 	// Place your snippets for javascript here. Each snippet is defined under a snippet name and has a prefix, body and 


### PR DESCRIPTION
VS Code supports a "JSON with comments" mode to annotate their JSON-formatted config files. On GitHub, you can use `jsonc` to have the syntax highlighter account for this.